### PR TITLE
feat: implement bulk board deletion with selection checkboxes

### DIFF
--- a/client/src/components/boards/BoardCard.jsx
+++ b/client/src/components/boards/BoardCard.jsx
@@ -3,7 +3,7 @@ import { useAuth } from '../../hooks/useAuth.jsx'
 import { Button } from '../common/Button.jsx'
 import { boardService } from '../../services/board.service.js'
 
-export function BoardCard({ board }) {
+export function BoardCard({ board, isSelected, onSelect }) {
   const navigate = useNavigate()
   const { user } = useAuth()
 
@@ -70,6 +70,15 @@ export function BoardCard({ board }) {
     }
   }
 
+  const checkboxStyles = {
+    position: 'absolute',
+    bottom: '15px',
+    right: '15px',
+    transform: 'scale(1.5)', 
+    cursor: 'pointer',
+    zIndex: 10, 
+  }
+
   return (
     <div
       style={cardStyles}
@@ -85,6 +94,16 @@ export function BoardCard({ board }) {
       )}
       {(board.access_type === 'owner' || user?.role === 'admin') && (
         <>
+        <input 
+          type="checkbox" 
+          checked={isSelected}
+          style={checkboxStyles}
+          onClick={(e) => e.stopPropagation()}
+          onChange={(e) => {
+            e.stopPropagation(); 
+            onSelect();
+          }}
+        />
           <Button
             variant="primary"
             size="sm"

--- a/client/src/components/boards/BoardCard.jsx
+++ b/client/src/components/boards/BoardCard.jsx
@@ -61,7 +61,7 @@ export function BoardCard({ board }) {
 
   const handleDelete = async (e) => {
     e.stopPropagation()
-    if (!confirm('Delete this board?')) return
+    if (!window.confirm(`Delete board "${board.name}"?`)) return
     try {
       await boardService.deleteBoard(board.id)
       window.location.reload()

--- a/client/src/components/boards/BoardList.jsx
+++ b/client/src/components/boards/BoardList.jsx
@@ -9,6 +9,7 @@ import { Button } from '../common/Button.jsx'
 
 export function BoardList() {
   const [boards, setBoards] = useState([])
+  const [selectedBoards, setSelectedBoards] = useState([]);
   const [newBoardName, setNewBoardName] = useState('')
   const [showPasswordModal, setShowPasswordModal] = useState(false)
   const { user, logout } = useAuth()
@@ -37,6 +38,26 @@ export function BoardList() {
       loadBoards()
     } catch (err) {
       console.error('Failed to create board', err)
+    }
+  }
+  
+  const toggleBoardSelection = (boardId) => {
+    setSelectedBoards((prev) => 
+      prev.includes(boardId) 
+        ? prev.filter(id => id !== boardId) 
+        : [...prev, boardId]               
+    )
+  }
+
+  const handleBulkDelete = async () => {
+    if (!window.confirm(`Are you sure you want to delete selected ${selectedBoards.length} boards?`)) return;
+    
+    try {
+      await Promise.all(selectedBoards.map(id => boardService.deleteBoard(id)));
+      setSelectedBoards([]); 
+      loadBoards(); 
+    } catch (err) {
+      console.error('Failed to delete boards', err);
     }
   }
 
@@ -127,11 +148,16 @@ export function BoardList() {
         <Button variant="success" size="lg" onClick={createBoard}>
           Create Board
         </Button>
+        {selectedBoards.length > 0 && (
+        <Button variant="danger" size="lg" onClick={handleBulkDelete}>
+        Delete Selected ({selectedBoards.length})
+        </Button>
+        )}
       </div>
 
       <div style={boardsGridStyles}>
         {boards.map((board) => (
-          <BoardCard key={board.id} board={board} />
+          <BoardCard key={board.id} board={board} isSelected={selectedBoards.includes(board.id)}  onSelect={() => toggleBoardSelection(board.id)}/>
         ))}
         {boards.length === 0 && (
           <p style={emptyStyles}>No boards yet. Create your first board!</p>


### PR DESCRIPTION
## Description
This PR addresses issue #16 by implementing a bulk deletion feature, allowing users to select multiple boards and delete them in a single action. This significantly improves the user experience for managing large numbers of boards.

**Changes made:**
* **`BoardList.jsx`**:
  * Added `selectedBoards` state to track IDs of boards marked for deletion.
  * Implemented `toggleBoardSelection` logic to handle adding/removing IDs from the selection list.
  * Added a "Delete Selected" button in the header that dynamically appears only when one or more boards are selected.
  * Implemented `handleBulkDelete` using `Promise.all` to efficiently delete all selected boards simultaneously.
* **`BoardCard.jsx`**:
  * Added a checkbox UI element to each card (only visible to owners/admins).
  * Implemented event propagation handling (`e.stopPropagation()`) to ensure clicking the checkbox doesn't accidentally open the board.
  * Connected the checkbox to the parent selection state via props.

## How to Test
1. Create 3 or 4 dummy boards.
2. Check the selection checkboxes on 2 of the boards.
3. Observe the red **"Delete Selected (2)"** button appear at the top.
4. Click the button and confirm the browser dialog.
5. Verify that both selected boards are removed from the list while the unselected ones remain.

Closes #16